### PR TITLE
Add OpenCaseLaw.ch to Switzerland section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Most resources are openly available.
 - [Fedlex](https://www.fedlex.admin.ch/) — Official Swiss federal law portal (RDF/Linked Data available). *(Open)*
 - [Swiss Federal Supreme Court (BGer/BGerentscheid)](https://www.bger.ch/) — Search engine for decisions. *(Open)*
 - [Entscheidsuche](https://entscheidsuche.ch/) — Meta-search across Swiss case law sources. *(Open)*
+- [OpenCaseLaw](https://opencaselaw.ch/) — 950k+ Swiss court decisions (federal & all 26 cantons) with citation graph, full-text search, and MCP API; bulk Parquet on Hugging Face. *(Open, API)* [(HF)](https://huggingface.co/datasets/voilaj/swiss-caselaw)
 - [Swisslex](https://www.swisslex.ch/) — Commercial Swiss legal research. *(Commercial)*
 - [Swiss-Judgment-Prediction: A Multilingual Legal Judgment Prediction Benchmark](https://arxiv.org/abs/2110.00806)
 


### PR DESCRIPTION
## Summary
- Adds [OpenCaseLaw.ch](https://opencaselaw.ch/) to the Switzerland section
- 950k+ Swiss court decisions from all federal courts and all 26 cantons
- Features: citation graph (8M+ edges), full-text search, MCP API
- Bulk Parquet dataset on [Hugging Face](https://huggingface.co/datasets/voilaj/swiss-caselaw)
- Fully open and free