### PR TITLE
Add AI Laws by State (50-state AI legislation tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Most resources are openly available.
 - [Fastcase](https://www.fastcase.com/) — Case law & statutes with citator; often via bar membership. *(Commercial)*
 - [Westlaw / Lexis+](https://legal.thomsonreuters.com/) • [Lexis+](https://www.lexisnexis.com/) — Comprehensive U.S. primary/secondary law & citators (KeyCite/Shepard’s). *(Commercial)*
 - [H2O Open Case Book](https://opencasebook.org/)
+- [AI Laws by State](https://www.ailawsbystate.com) — 50-state tracker for U.S. artificial intelligence legislation, sourced from primary state legislature feeds. Covers bill status, effective dates, penalty structures, and topic categorization (deepfakes, hiring, healthcare AI, disclosure, bias audits). *(Open)*
 
 
 ### Canada


### PR DESCRIPTION
This adds [AI Laws by State](https://www.ailawsbystate.com), a free 50-state tracker for U.S. AI legislation that covers:

- Bill status, effective dates, and penalty structures across all 50 states
- Topic-specific trackers (deepfakes, hiring, healthcare AI, disclosure, bias audits)
- Primary-source linked — every entry cites the official state legislature URL
- Free tier covers state pages, bill detail, and basic search; Pro tier for CSV exports, alerts, comparison tools, and full historical data

Fits in the **United States** section because it is an open public-interest dataset for U.S. AI legislation — updated from primary state legislature feeds.

Happy to adjust formatting or section placement to match your conventions.