### PR TITLE
Add Avukatistan to Turkey legal data resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Most resources are openly available.
 
 ### Turkey
 - [https://acikveri.yagiz.dev/] - Open Legal Turkey
+- [Avukatistan](https://avukatistan.com) — Turkish legal research platform with case law, legislation, legal questions, and lawyer profile data. *(Open)*
 
 ## North America
 


### PR DESCRIPTION
Adds Avukatistan to the Turkey section as a Turkish legal research platform covering case law, legislation, legal questions, and lawyer profile data.