### PR TITLE
Add MiniLex 7-domain Korean lawdata to South Korea section

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Most resources are openly available.
 
 ## South Korea
 - [https://open.law.go.kr/LSO/openApi/guideList.do] - Open Legal Data
+- [MiniLex 7-domain Korean lawdata (wellsa-ai)](https://minilex.wellsa.ai) — Korean public legal corpora unified: statutes (5,589), administrative rules (10,765), court precedents (171,014), statutory interpretations (8,728), constitutional court decisions (38,092), local ordinances (159,910), treaties (6,907). 397K+ Markdown docs, MIT licensed, daily cron updates. *(Open, API)* [[HF](https://huggingface.co/wellsa-ai)] [[GitHub](https://github.com/wellsa-ai)]
 
 ### Russia
 - [https://github.com/irlcode/RusLawOD] - Open Legal Data


### PR DESCRIPTION
## Summary

Adds **MiniLex / wellsa-ai 7-domain Korean lawdata** to the **South Korea** section.

- 7 sibling HF datasets / GitHub repos: statutes / admin rules / precedents / statutory interpretations / constitutional decisions / local ordinances / treaties
- **397K+** Markdown documents, MIT licensed, daily cron updates with Git history provenance
- Production demo: https://minilex.wellsa.ai (1.36M+ articles indexed, source-cited Q&A)
- HF org: https://huggingface.co/wellsa-ai
- GitHub canonical: https://github.com/wellsa-ai

Source data: Korean Ministry of Government Legislation public OpenAPI. wellsa-ai provides Markdown normalization + daily cron + Git history layer.

5 civic scenarios validated (deepfake takedown, unpaid wages, unfair dismissal, personal data leakage, stalking).

Thanks for maintaining this list!