### PR TITLE
Add Advottic Legal Data (US statute of limitations + templates, CC BY 4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Most resources are openly available.
 - [Westlaw / Lexis+](https://legal.thomsonreuters.com/) • [Lexis+](https://www.lexisnexis.com/) — Comprehensive U.S. primary/secondary law & citators (KeyCite/Shepard’s). *(Commercial)*
 - [H2O Open Case Book](https://opencasebook.org/)
 - [AI Laws by State](https://www.ailawsbystate.com) — 50-state tracker for U.S. artificial intelligence legislation, sourced from primary state legislature feeds. Covers bill status, effective dates, penalty structures, and topic categorization (deepfakes, hiring, healthcare AI, disclosure, bias audits). *(Open)*
+- [Advottic Legal Data](https://github.com/TechnoOptics/legal-data) — US statute of limitations across 51 jurisdictions (50 states + DC) and 9 claim categories (personal injury, contract, fraud, defamation, medical malpractice, wrongful death, debt collection); plus 5 lawyer-reviewed legal templates with tokenized body text. JSON datasets, CC BY 4.0. [Live JSON endpoints](https://advottic.com/open-data) with permissive CORS. *(Open, API)*
 
 
 ### Canada


### PR DESCRIPTION
Adding **Advottic Legal Data**, a CC BY 4.0 JSON dataset published by Techno Optics LLC, to the United States section.

### What it covers

- **`statute-of-limitations.json`**: US statute of limitations across **51 jurisdictions** (50 states + DC) and **9 claim categories** (personal injury, written contract, oral contract, property damage, fraud, defamation, medical malpractice, wrongful death, debt collection). Each entry includes the controlling time window in years and the relevant caveat (discovery rule, statute of repose, foreign-object exception). Last reviewed 2026-06-08.
- **`templates.json`**: 5 lawyer-reviewed legal templates with context, warnings, and tokenized body text (demand letter, mutual NDA, cease-and-desist, lease termination notice, security deposit return demand).

### Links

- Repo: https://github.com/TechnoOptics/legal-data
- Live JSON endpoints: https://advottic.com/open-data
- Schema.org Dataset markup served at both endpoints
- Citation: `Techno Optics LLC. (2026). Advottic Legal Data. https://github.com/TechnoOptics/legal-data. CC BY 4.0.`

### Why this fits

- Genuinely open: CC BY 4.0, JSON, permissive CORS, examples for Python and Node included in the repo.
- Filling a gap: the existing United States section is heavy on case law and federal sources. A state-by-state statute-of-limitations dataset (and free templates with tokenized fields) addresses a different use case that AI / research tooling has been re-scraping for years.
- Maintained: reviewed annually each January; we re-publish whenever a state legislature updates a window.

Happy to revise the entry copy or move it elsewhere if you prefer. Thanks for maintaining this list.