### PR TITLE
Add Lien Deadlines — open US mechanics-lien-deadline dataset (CA/TX/FL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Most resources are openly available.
 - [H2O Open Case Book](https://opencasebook.org/)
 - [AI Laws by State](https://www.ailawsbystate.com) — 50-state tracker for U.S. artificial intelligence legislation, sourced from primary state legislature feeds. Covers bill status, effective dates, penalty structures, and topic categorization (deepfakes, hiring, healthcare AI, disclosure, bias audits). *(Open)*
 - [Advottic Legal Data](https://github.com/TechnoOptics/legal-data) — US statute of limitations across 51 jurisdictions (50 states + DC) and 9 claim categories (personal injury, contract, fraud, defamation, medical malpractice, wrongful death, debt collection); plus 5 lawyer-reviewed legal templates with tokenized body text. JSON datasets, CC BY 4.0. [Live JSON endpoints](https://advottic.com/open-data) with permissive CORS. *(Open, API)*
+- [Lien Deadlines](https://github.com/iPythoning/lien-deadlines) — US mechanics/construction lien deadlines for CA, TX & FL by claimant role (direct contractor / subcontractor), with verbatim statute citations (CA Civil Code §8000 et seq., TX Property Code ch. 53, FL Statutes ch. 713) and conditional rules (e.g. Notice-of-Completion reductions). JSON + CSV, CC BY 4.0. [Live reference + calculator](https://ipythoning.github.io/lien-deadlines/). *(Open)*
 
 
 ### Canada


### PR DESCRIPTION
## What this adds

One entry under **North America → United States**, placed next to the existing per-jurisdiction structured-data entries (AI Laws by State, Advottic Legal Data):

> **Lien Deadlines** — US mechanics/construction lien deadlines for CA, TX & FL by claimant role (direct contractor / subcontractor), with verbatim statute citations (CA Civil Code §8000 et seq., TX Property Code ch. 53, FL Statutes ch. 713) and conditional rules (e.g. Notice-of-Completion reductions). JSON + CSV, CC BY 4.0. Live reference + calculator. *(Open)*

## Why it fits

- **Structured, statute-cited legal reference data** — same shape as the adjacent *Advottic Legal Data* (statute of limitations across jurisdictions) and *AI Laws by State* entries already in this section.
- **Openly licensed**: CC BY 4.0, machine-readable JSON + CSV at stable URLs.
- Repo: https://github.com/iPythoning/lien-deadlines · Live: https://ipythoning.github.io/lien-deadlines/ · Dataset: https://ipythoning.github.io/lien-deadlines/data/deadlines.json

## Honest scope note

Coverage is currently **3 states (CA/TX/FL) × 2 roles**, v0.1.0, last verified 2026-06-10. It is an informational reference (statute citations + a deadline calculator), **not legal advice** — disclaimers are prominent throughout the site and dataset. Marked *(Open)* rather than *(API)* since there is no documented public API, only static dataset files.