### PR TITLE
Add SettleSignal (US class-action & refund settlements)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Most resources are openly available.
 - [Federal Register](https://www.federalregister.gov/) — Daily federal rules/notices; full [API](https://www.federalregister.gov/). *(Open, API)*
 - [case.law (Caselaw Access Project)](https://case.law/) — ~6.7M U.S. opinions (1658–2018); bulk & [API](https://case.law/). *(Open, API)*
 - [CourtListener](https://www.courtlistener.com/) — Millions of opinions + dockets via RECAP; robust [API](https://www.courtlistener.com/)/bulk. *(Open, API)*
+- [SettleSignal](https://settlesignal.com/data/settlements.json) — Verified U.S. class-action & refund settlement catalog (claim deadlines, proof rules, status, official claim links) as open JSON; public fields free with attribution. *(Open, API)*
 - [Free Law Project](https://free.law).
 - [PACER](https://pacer.uscourts.gov/) — Federal court dockets & filings (fees apply). *(Commercial/Gov)*
 - [Oyez](https://www.oyez.org/) — SCOTUS audio, transcripts, and case summaries (education-oriented). *(Open)*


### PR DESCRIPTION
Adds SettleSignal under North America › United States — a verified, free-with-attribution open-data catalog of US class-action & refund settlements (deadlines, proof rules, official claim links) as machine-readable JSON: https://settlesignal.com/data/settlements.json